### PR TITLE
Don't Replace Existing Shake ID When Saving Posts

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -41,15 +41,6 @@
               </button>
             </li>
           </ul>
-          <h2>To-Do List</h2>
-          <ul>
-            <li>Load shake via pathname instead of ID.</li>
-            <li>Posts should be able to belong to more than one shake.</li>
-            <li>Load data for special pages like incoming and popular.</li>
-            <li>Load comments for posts on post detail page.</li>
-            <li>Paginate posts.</li>
-            <li>Any styling, like, at all?</li>
-          </ul>
         </template>
         <template v-else>
           <button

--- a/store/post.js
+++ b/store/post.js
@@ -46,12 +46,34 @@ export const actions = {
       return;
     }
 
-    // Add the shake object and ID
-    // TODO: this makes an association but is destructive of any existing associations
+    // grab the list of sharedfiles
     const posts = result.sharedfiles;
+
+    // Add the shake ID to the post, preserving any existing shake IDs
     if (options.shakeId) {
       posts.forEach(post => {
-        post.shakes = [{ id: options.shakeId }];
+        // empty array to hold the final shake objects
+        const shakeObjects = [];
+
+        // empty set to hold shake IDs
+        const shakeSet = new Set();
+
+        // load the post from the store if it already exists
+        const existingPost = Post.find(post.sharekey);
+
+        // add the current shake's ID to the set
+        shakeSet.add(options.shakeId);
+
+        // if the existing post has any shakes, add them to the set
+        if (existingPost && existingPost.shake_ids) {
+          existingPost.shake_ids.forEach(id => shakeSet.add(id));
+        }
+
+        // add each ID from the set to the array as an object
+        shakeSet.forEach(id => shakeObjects.push({ id }));
+
+        // add the shake ID objects to the post so Vuex ORM can read them
+        post.shakes = shakeObjects;
       });
     }
 


### PR DESCRIPTION
This commit fixes a bug where when a post was saved, it always replaced
the list of shakes the post was associated with. Now it should preserve
any existing shakes as well as adding the current shake.

Fixes #5